### PR TITLE
Spawn a new asynchronous task for the http server

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -56,6 +56,11 @@ async fn main() {
             for event in receiver {
                 println!("tidybee-agent: new event: {event:?}");
             }
+
+            tokio::spawn(async move {
+                server.server_start().await;
+            });
+
             watch_directories_thread.join().unwrap();
         }
         Err(error) => {
@@ -63,5 +68,4 @@ async fn main() {
             process::exit(1);
         }
     }
-    server.server_start().await;
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -44,6 +44,10 @@ async fn main() {
                 }
             }
 
+            tokio::spawn(async move {
+                server.server_start().await;
+            });
+
             let (sender, receiver) = crossbeam_channel::unbounded();
             let watch_directories_thread: thread::JoinHandle<()> = thread::spawn(move || {
                 watcher::watch_directories(
@@ -56,10 +60,6 @@ async fn main() {
             for event in receiver {
                 println!("tidybee-agent: new event: {event:?}");
             }
-
-            tokio::spawn(async move {
-                server.server_start().await;
-            });
 
             watch_directories_thread.join().unwrap();
         }


### PR DESCRIPTION
The main problem we had when trying to start the http server alongside the watcher is that the http server needs to be spawned in an async task. This PR addresses the issue by spawning a new task using `tokio::spawn` then moving the http_server inside it